### PR TITLE
Mobile fixes

### DIFF
--- a/client/src/app/gearset-list/gearset-list.component.css
+++ b/client/src/app/gearset-list/gearset-list.component.css
@@ -3,6 +3,12 @@
 	margin-right: 48px;
 }
 
+@media only screen and (max-width: 1280px) {
+	.gearset-table {
+		overflow: scroll;
+	}
+}
+
 .gearset-table th {
 	padding-top: 8px;
 	padding-bottom: 8px;

--- a/client/src/app/gearset-list/gearset-list.component.css
+++ b/client/src/app/gearset-list/gearset-list.component.css
@@ -9,6 +9,10 @@
 	}
 }
 
+.ant-table-row {
+	background: #141414;
+}
+
 .gearset-table th {
 	padding-top: 8px;
 	padding-bottom: 8px;

--- a/client/src/app/gearset-list/gearset-list.component.html
+++ b/client/src/app/gearset-list/gearset-list.component.html
@@ -1,4 +1,5 @@
-<nz-table #basicTable class="gearset-table" [nzData]="dataSet" nzShowPagination=false>
+<nz-table #basicTable class="gearset-table" [nzData]="dataSet"
+    nzShowPagination=false [nzScroll]=scrollSize>
   <thead>
     <tr>
       <th rowspan="2">Set name</th>

--- a/client/src/app/gearset-list/gearset-list.component.html
+++ b/client/src/app/gearset-list/gearset-list.component.html
@@ -1,5 +1,5 @@
-<nz-table #basicTable class="gearset-table" [nzData]="dataSet"
-    nzShowPagination=false [nzScroll]=scrollSize>
+<nz-table #basicTable class="gearset-table" [nzData]="dpsService.dataSet"
+    nzShowPagination=false>
   <thead>
     <tr>
       <th rowspan="2">Set name</th>
@@ -71,7 +71,7 @@
               [(ngModel)]="editCache[data.id].data.pie" />
         </td>
         <td class="num-col">
-          <td class="num-col">{{data.gcd}}
+          {{data.gcd}}
         </td>
         <td class="num-col">{{data.mp}}
         </td>

--- a/client/src/app/party-select/party-select.component.css
+++ b/client/src/app/party-select/party-select.component.css
@@ -1,6 +1,7 @@
 .party-select-container {
 	margin: 12px 24px;
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: center;
 }
 


### PR DESCRIPTION
Wrap the party icons if the screen is too small to fit them all in one row.  Scroll the table horizontally if the screen is less than ~1280px (I don't want to make the columns any smaller because they end up uneditable).