### PR TITLE
add doc requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 from setuptools import setup, find_packages
 
+doc_requirements = [
+    'pdoc3',
+]
+
 with open('README.md', 'r') as f:
     long_description = f.read()
 
@@ -16,4 +20,7 @@ setup(
     packages=find_packages('backend'),
     package_dir={'': 'backend'},
     install_requires=requirements,
+    extras_require={
+        'docs': doc_requirements,
+    }
 )


### PR DESCRIPTION
Inroads into fixing #58

However, the docs currently fail because it can't resolve import paths. I propose this stay as a draft PR until at least #39 is completed (also, some of the suggested breakup between frontend and backend restructuring should fix this)