### PR TITLE
Logic fixes

### DIFF
--- a/backend/xivdpscalc/character/__init__.py
+++ b/backend/xivdpscalc/character/__init__.py
@@ -3,6 +3,7 @@
 import math
 from typing import Optional
 from dataclasses import dataclass
+
 from xivdpscalc.character.stat import Stat, Stats, ProbabalisticStat
 from xivdpscalc.character.jobs import Roles, Buffs, Comp, Jobs
 
@@ -31,6 +32,7 @@ class Character:
         """
         self.job = job
         self.wd = stat_spread.wd
+        # TODO: separate probablistic stats from regular stats
         self.character_stats = {
             Stats.MAINSTAT: Stat(Stats.MAINSTAT, stat_spread.mainstat),
             Stats.DET: Stat(Stats.DET, stat_spread.det),
@@ -62,9 +64,8 @@ class Character:
         """
         return 200 + self.character_stats[Stats.PIE].get_multiplier()
 
-    # todo: break this up neatly
-    def calc_damage(self, potency_per_second: float, comp: Comp, is_dot: bool = False,
-                    crit_rate: Optional[float] = None, dh_rate: Optional[float] = None) -> float:  #pylint: disable=too-many-arguments, too-many-locals
+    def calc_non_probablistic_damage(self, potency_per_second: float, comp: Optional[Comp],
+                                     is_dot: bool = False) -> float:
         """
         Calculates the damage from non probablistic stats.
         :param potency_per_second: From potency calculated on expected rotation
@@ -74,7 +75,7 @@ class Character:
         """
 
         # modify mainstat according to number of roles if with a team composition
-        if comp is not None:
+        if comp:
             unique_role_bonus = 1 + 0.01 * comp.n_roles
             new_mainstat_value = math.floor(self.character_stats[Stats.MAINSTAT].value * unique_role_bonus)
             mainstat = Stat(Stats.MAINSTAT, new_mainstat_value)
@@ -93,8 +94,9 @@ class Character:
 
         return np_damage
 
-    def calc_probablistic_damage(self, np_damage: float, comp: Comp = None, crit_rate: float = None,
-                                 dh_rate: float = None) -> float:
+    def calc_probablistic_damage(self, np_damage: float, comp: Optional[Comp] = None,
+                                 crit_rate: Optional[float] = None,
+                                 dh_rate: Optional[float] = None) -> float:
         """
         Calculates the damage from probablistic stats.
         :param np_damage: from nonprobablistic damage calculation
@@ -136,7 +138,7 @@ class Character:
         return p_damage
 
     # todo: break this up neatly
-    def calc_damage(self, potency_per_second: float, comp: Comp = None,  # pylint: disable=too-many-arguments
+    def calc_damage(self, potency_per_second: float, comp: Optional[Comp] = None,  # pylint: disable=too-many-arguments
                     is_dot: bool = False, crit_rate: float = None, dh_rate: float = None) -> float:
         """
         Calculates the estimated DPS based on the team composition and current character stats

--- a/backend/xivdpscalc/character/__init__.py
+++ b/backend/xivdpscalc/character/__init__.py
@@ -25,6 +25,10 @@ class Character:
     The main class where damage is calculated. Initialized by providing a CharacterStatSpread.
     """
     def __init__(self, job: Jobs, stat_spread: CharacterStatSpread):
+        """
+        :param job: Job enum, tells the character's job
+        :param stat_spread: dataclass containing all the attributes
+        """
         self.job = job
         self.wd = stat_spread.wd
         self.character_stats = {
@@ -141,7 +145,6 @@ class Character:
         :param dh_rate: Optional parameter to override dh rate to calculate specific proc rate
         :returns: the DPS number
         """
-
         damage = self.calc_non_probablistic_damage(potency_per_second, comp, is_dot)
         damage //= 100  # why? i do not know. cargo culted
 

--- a/backend/xivdpscalc/character/__init__.py
+++ b/backend/xivdpscalc/character/__init__.py
@@ -32,7 +32,6 @@ class Character:
         """
         self.job = job
         self.wd = stat_spread.wd
-        # TODO: separate probablistic stats from regular stats
         self.character_stats = {
             Stats.MAINSTAT: Stat(Stats.MAINSTAT, stat_spread.mainstat),
             Stats.DET: Stat(Stats.DET, stat_spread.det),
@@ -64,18 +63,21 @@ class Character:
         """
         return 200 + self.character_stats[Stats.PIE].get_multiplier()
 
-    def calc_non_probablistic_damage(self, potency_per_second: float, comp: Optional[Comp],
-                                     is_dot: bool = False) -> float:
+    # todo: break this up neatly
+    def calc_damage(self, potency_per_second: float, comp: Comp, is_dot: bool = False,
+                    crit_rate: Optional[float] = None, dh_rate: Optional[float] = None) -> float:  #  pylint: disable=too-many-arguments, too-many-locals
         """
         Calculates the damage from non probablistic stats.
         :param potency_per_second: From potency calculated on expected rotation
         :param comp: Team composition, if applicable
         :param is_dot: If potency also applies to DoT
+        :param crit_rate: optional parameter to override crit rate from gear
+        :param dh_rate: optional parameter to override crit rate from gear
         :returns: DPS contribution from non-probablistic stats
         """
 
         # modify mainstat according to number of roles if with a team composition
-        if comp:
+        if comp is not None:
             unique_role_bonus = 1 + 0.01 * comp.n_roles
             new_mainstat_value = math.floor(self.character_stats[Stats.MAINSTAT].value * unique_role_bonus)
             mainstat = Stat(Stats.MAINSTAT, new_mainstat_value)
@@ -84,31 +86,22 @@ class Character:
 
         # job bonus for weapon damage
         adjusted_wd = self.wd + (340 * self.job.job_mod // 1000)
-        np_damage = potency_per_second * adjusted_wd * (100 + mainstat.get_multiplier()) // 100
+        damage = potency_per_second * adjusted_wd * (100 + mainstat.get_multiplier()) // 100
 
-        # applying the damage bonus from wimpy secondary stats
-        np_damage = self.character_stats[Stats.DET].apply_stat(np_damage)
-        np_damage = self.character_stats[Stats.TEN].apply_stat(np_damage)
+        # applying the damage bonus from secondary stats
+        damage = self.character_stats[Stats.DET].apply_stat(damage)
+        damage = self.character_stats[Stats.TEN].apply_stat(damage)
         if is_dot:
-            np_damage = self.character_stats[Stats.SPEED].apply_stat(np_damage)
+            damage = self.character_stats[Stats.SPEED].apply_stat(damage)
 
-        return np_damage
+        damage //= 100  # why? i do not know. cargo culted
 
-    def calc_probablistic_damage(self, np_damage: float, comp: Optional[Comp] = None,
-                                 crit_rate: Optional[float] = None,
-                                 dh_rate: Optional[float] = None) -> float:
-        """
-        Calculates the damage from probablistic stats.
-        :param np_damage: from nonprobablistic damage calculation
-        :param comp: Team composition, if applicable
-        :param crit_rate: for calculating a specific crit proc rate
-        :param dh_rate: for calculating a specific dh proc rate
-        :returns: DPS contribution from probablistic stats
-        """
+        if self.job.role == Roles.HEALER:
+            damage = math.floor(damage * 1.3)  # magic and mend
 
         # damage effect of probabalistic stats
-        crit_damage = self.character_stats[Stats.CRIT].apply_stat(np_damage)
-        dh_damage = np_damage * self.character_stats[Stats.DH].stat.m_factor // 1000
+        crit_damage = self.character_stats[Stats.CRIT].apply_stat(damage)
+        dh_damage = damage * self.character_stats[Stats.DH].stat.m_factor // 1000
         cdh_damage = crit_damage * self.character_stats[Stats.DH].stat.m_factor // 1000
 
         # use expected crit rate based on stats if none is supplied
@@ -130,39 +123,15 @@ class Character:
         assert dh_rate is not None  # for mypy
         cdh_rate = crit_rate * dh_rate
         normal_rate = 1 - crit_rate - dh_rate + cdh_rate
-        p_damage = np_damage * normal_rate + (
+        damage = damage * normal_rate + (
             crit_damage * (crit_rate - cdh_rate)) + (
             dh_damage * (dh_rate - cdh_rate)) + (
             cdh_damage * cdh_rate)
-
-        return p_damage
-
-    # todo: break this up neatly
-    def calc_damage(self, potency_per_second: float, comp: Optional[Comp] = None,  # pylint: disable=too-many-arguments
-                    is_dot: bool = False, crit_rate: float = None, dh_rate: float = None) -> float:
-        """
-        Calculates the estimated DPS based on the team composition and current character stats
-        :param potency_per_second: Potency calculated on expected rotation
-        :param comp: Team composition
-        :param is_dot: The potency is applying to a DoT effect, which is additionally modified by spellspeed
-        :param crit_rate: Optional parameter to override crit rate to calculate specific proc rate
-        :param dh_rate: Optional parameter to override dh rate to calculate specific proc rate
-        :returns: the DPS number
-        """
-        damage = self.calc_non_probablistic_damage(potency_per_second, comp, is_dot)
-        damage //= 100  # why? i do not know. cargo culted
-
-        # damage effect of job traits / stance
-        # todo: pull out traits
-        if self.job.role == Roles.HEALER:
-            damage = math.floor(damage * 1.3)  # magic and mend
-
-        total_damage = self.calc_probablistic_damage(damage, comp, crit_rate, dh_rate)
 
         # apply raid buffs that boost damage
         if comp is not None:
             for buff in comp.raidbuffs:
                 if buff in Buffs.damage_buffs():
-                    total_damage *= (1 + buff.avg_buff_effect(self.job))
+                    damage *= (1 + buff.avg_buff_effect(self.job))
 
-        return total_damage
+        return damage

--- a/backend/xivdpscalc/character/__init__.py
+++ b/backend/xivdpscalc/character/__init__.py
@@ -74,7 +74,7 @@ class Character:
         """
 
         # modify mainstat according to number of roles if with a team composition
-        if comp:
+        if comp is not None:
             affirmative_action_bonus = 1 + 0.01 * comp.n_roles
             new_mainstat_value = math.floor(self.character_stats[Stats.MAINSTAT].value * affirmative_action_bonus)
             mainstat = Stat(Stats.MAINSTAT, new_mainstat_value)
@@ -110,13 +110,13 @@ class Character:
         cdh_damage = crit_damage * self.character_stats[Stats.DH].stat.m_factor // 1000
 
         # use expected crit rate based on stats if none is supplied
-        if not crit_rate:
+        if crit_rate is None:
             crit_rate = self.character_stats[Stats.CRIT].get_p()
-        if not dh_rate:
+        if dh_rate is None:
             dh_rate = self.character_stats[Stats.DH].get_p()
 
         # apply party crit/dh buffs if applicable
-        if comp:
+        if comp is not None:
             for buff in comp.raidbuffs:
                 if buff in Buffs.crit_buffs():
                     crit_rate += buff.avg_buff_effect(self.job)
@@ -124,6 +124,8 @@ class Character:
                     dh_rate += buff.avg_buff_effect(self.job)
 
         # apply probablistic modifiers
+        assert crit_rate is not None  # for mypy
+        assert dh_rate is not None  # for mypy
         cdh_rate = crit_rate * dh_rate
         normal_rate = 1 - crit_rate - dh_rate + cdh_rate
         p_damage = np_damage * normal_rate + (
@@ -156,8 +158,9 @@ class Character:
         total_damage = self.calc_probablistic_damage(damage, comp, crit_rate, dh_rate)
 
         # apply raid buffs that boost damage
-        for buff in comp.raidbuffs:
-            if buff in Buffs.damage_buffs():
-                total_damage *= (1 + buff.avg_buff_effect(self.job))
+        if comp is not None:
+            for buff in comp.raidbuffs:
+                if buff in Buffs.damage_buffs():
+                    total_damage *= (1 + buff.avg_buff_effect(self.job))
 
         return total_damage

--- a/backend/xivdpscalc/character/__init__.py
+++ b/backend/xivdpscalc/character/__init__.py
@@ -75,8 +75,8 @@ class Character:
 
         # modify mainstat according to number of roles if with a team composition
         if comp is not None:
-            affirmative_action_bonus = 1 + 0.01 * comp.n_roles
-            new_mainstat_value = math.floor(self.character_stats[Stats.MAINSTAT].value * affirmative_action_bonus)
+            unique_role_bonus = 1 + 0.01 * comp.n_roles
+            new_mainstat_value = math.floor(self.character_stats[Stats.MAINSTAT].value * unique_role_bonus)
             mainstat = Stat(Stats.MAINSTAT, new_mainstat_value)
         else:
             mainstat = self.character_stats[Stats.MAINSTAT]

--- a/backend/xivdpscalc/character/jobs.py
+++ b/backend/xivdpscalc/character/jobs.py
@@ -52,7 +52,7 @@ class Buffs(Enum):
         return {cls.BV, cls.BARD_DH, cls.DEVILMENT}
 
     @classmethod
-    def raid_buffs(cls):
+    def damage_buffs(cls):
         """ Lists damage buffs """
         return {cls.DIV, cls.TRICK, cls.BROTHERHOOD, cls.BARD_DMG, cls.TECH, cls.DEVOTION, cls.EMBOLDEN}
 

--- a/backend/xivdpscalc/character/jobs.py
+++ b/backend/xivdpscalc/character/jobs.py
@@ -1,6 +1,7 @@
 """ Representation of static information at the class level """
 
 from enum import Enum, auto
+from dataclasses import dataclass
 import itertools
 
 class Roles(Enum):
@@ -13,7 +14,9 @@ class Roles(Enum):
 
 
 class Buffs(Enum):
-    """ Buffs enum representing (magnitude, duration, cooldown) in seconds """
+    """
+    List of all buffs in the game. Each buff has three parameters: magnitude, duration, cooldown, in seconds.
+    """
     # aoe
     CHAIN = (0.1, 15, 120)
     DIV = (0.06, 15, 120)  # 3 seal div
@@ -36,10 +39,10 @@ class Buffs(Enum):
 
     # todo: should probably add standard, personal tank buffs
 
-    def __init__(self, multiplier: float, duration: int, cooldown: int):
+    def __init__(self, multiplier: float, duration_sec: int, cooldown_sec: int):
         self.multiplier = multiplier
-        self.duration = duration
-        self.cooldown = cooldown
+        self.duration_sec = duration_sec
+        self.cooldown_sec = cooldown_sec
 
     @classmethod
     def crit_buffs(cls):
@@ -58,16 +61,16 @@ class Buffs(Enum):
 
     def avg_buff_effect(self, job):
         """ Calculates the average impact of buffs considering its uptime and magnitude """
-        total = 0
-        if self.name == 'EMBOLDEN':  #pylint: disable=comparison-with-callable
+        if self.name == 'EMBOLDEN':   # pylint: disable=comparison-with-callable
             if job == Jobs.RDM or job.role in {Roles.TANK, Roles.MELEE, Roles.RANGED}:
                 decay_interval = 4
                 decay_rate = 0.2
-                for i in range(self.duration / decay_interval):
-                    total += self.multiplier * (1 - decay_rate * i) * decay_interval / self.cooldown
-                return total
+                decay_ticks = self.duration_sec // decay_interval
+                intervals = (self.multiplier * (1 - decay_rate * tick) * decay_interval / self.cooldown_sec
+                             for tick in range(decay_ticks))
+                return sum(intervals)
             return 0 # Sucks to not have Embolden apply, I guess
-        return self.multiplier * self.duration / self.cooldown
+        return self.multiplier * self.duration_sec / self.cooldown_sec
 
 class Jobs(Enum):
     """
@@ -80,14 +83,13 @@ class Jobs(Enum):
     job modifiers from https://www.akhmorning.com/allagan-studies/modifiers/
     note: tanks use STR for damage
     """
-
     SCH = (115, Roles.HEALER, [Buffs.CHAIN])
     AST = (115, Roles.HEALER, [Buffs.DIV])
     WHM = (115, Roles.HEALER, [])
-    PLD = (110, Roles.TANK, [])
-    WAR = (110, Roles.TANK, [])
-    DRK = (110, Roles.TANK, [])
-    GNB = (110, Roles.TANK, [])
+    PLD = (100, Roles.TANK, [])
+    WAR = (105, Roles.TANK, [])
+    DRK = (105, Roles.TANK, [])
+    GNB = (100, Roles.TANK, [])
     NIN = (110, Roles.MELEE, [Buffs.TRICK])
     DRG = (115, Roles.MELEE, [Buffs.LITANY])
     MNK = (110, Roles.MELEE, [Buffs.BROTHERHOOD])
@@ -99,10 +101,10 @@ class Jobs(Enum):
     BLM = (115, Roles.CASTER, [])
     RDM = (115, Roles.CASTER, [Buffs.EMBOLDEN])
 
-    def __init__(self, job_mod: int, role: Roles, raidbuff: list[Buffs]):
+    def __init__(self, job_mod: int, role: Roles, raidbuffs: list[Buffs]):
         self.job_mod = job_mod
         self.role = role
-        self.raidbuff = raidbuff
+        self.raidbuffs = raidbuffs
 
     @staticmethod
     def create_job(name: str):
@@ -132,11 +134,25 @@ class Jobs(Enum):
 
         return job_string_to_enum[name]
 
+@dataclass(init=False)
+class Comp:
+    """
+    The party composition.
 
-class Comp:  #pylint: disable=too-few-public-methods
-    """ Representation of a comp, basically a collection of Jobs """
+    jobs: A list of all jobs in the party (may contain duplicates).
+    raidbuffs: A set of unique raidbuffs in the party.
+    n_roles: A number (1-5) indicating how many unique roles are in the party.
+    """
 
     def __init__(self, jobs: list[Jobs]):
-        self.jobs = jobs
-        self.raidbuffs: set[Buffs] = set(itertools.chain.from_iterable([job.raidbuff for job in jobs]))
+        """
+        :param jobs: A list of Jobs in the party composition
+
+        jobs: A list of all jobs in the party (may contain duplicates).
+        raidbuffs: A set of unique raidbuffs in the party.
+        n_roles: A number (1-5) indicating how many unique roles are in the party.
+        """
+
+        self.jobs: list[Jobs] = jobs
+        self.raidbuffs: set[Buffs] = set(itertools.chain.from_iterable([job.raidbuffs for job in jobs]))
         self.n_roles: int = len({job.role for job in jobs})

--- a/backend/xivdpscalc/character/stat.py
+++ b/backend/xivdpscalc/character/stat.py
@@ -7,9 +7,6 @@ import math
 class Stats(Enum):
     """
     Contains math factors for each individual stat.
-    base: the base value for each stat
-    m_factor: ???
-    m_scalar: ???
     """
     MAINSTAT = (340, 165, 0)
     DET = (340, 130, 0)

--- a/backend/xivdpscalc/character/stat.py
+++ b/backend/xivdpscalc/character/stat.py
@@ -22,7 +22,7 @@ class Stats(Enum):
         """
         :param base: the base value for each stat.
         :param m_factor: magic value for magic math, fits the reverse engineered formula.
-        :param m_scalar: magic value for magic math, fits the reverse engineer formula.
+        :param m_scalar: magic value for magic math, fits the reverse engineered formula.
         """
         self.base = base
         self.m_factor = m_factor


### PR DESCRIPTION
-Renames variables for clarity
-Breaks apart calc_damage into nonprobablistic and probablistic functions
-Allows calc_damage to use Comp as optional
-Cleans up embolden calculation
-Cleans up init for probabilistic stats
-Fixes job modifier for tanks

